### PR TITLE
:alien: Replace zgw-consumers-ext usage

### DIFF
--- a/prefill_haalcentraalhr/client.py
+++ b/prefill_haalcentraalhr/client.py
@@ -1,7 +1,7 @@
 # Shipped in Open Forms
 from openforms.contrib.hal_client import HALClient
 from openforms.pre_requests.clients import PreRequestMixin
-from zgw_consumers_ext.api_client import ServiceClientFactory
+from zgw_consumers.client import build_client
 
 from .models import HaalCentraalHRConfig
 
@@ -15,8 +15,7 @@ def get_client(**kwargs) -> "Client":
     assert isinstance(config, HaalCentraalHRConfig)
     if not (service := config.service):
         raise NoServiceConfigured("No service configured!")
-    service_client_factory = ServiceClientFactory(service)
-    return Client.configure_from(service_client_factory, **kwargs)
+    return build_client(service, client_factory=Client, **kwargs)
 
 
 class Client(PreRequestMixin, HALClient):

--- a/prefill_haalcentraalhr/tests/test_plugin.py
+++ b/prefill_haalcentraalhr/tests/test_plugin.py
@@ -9,7 +9,7 @@ from openforms.plugins.exceptions import InvalidPluginConfiguration
 from openforms.submissions.tests.factories import SubmissionFactory
 from requests_mock import Mocker
 from zgw_consumers.constants import APITypes
-from zgw_consumers_ext.tests.factories import ServiceFactory
+from zgw_consumers.test.factories import ServiceFactory
 
 from ..models import HaalCentraalHRConfig
 from ..plugin import HaalCentraalHRPrefill

--- a/prefill_haalcentraalhr/tests/test_plugin_with_token_exchange.py
+++ b/prefill_haalcentraalhr/tests/test_plugin_with_token_exchange.py
@@ -14,7 +14,7 @@ from openforms.submissions.tests.factories import SubmissionFactory
 from requests.auth import AuthBase
 from requests_mock import Mocker
 from zgw_consumers.constants import APITypes
-from zgw_consumers_ext.tests.factories import ServiceFactory
+from zgw_consumers.test.factories import ServiceFactory
 
 from ..models import HaalCentraalHRConfig
 from ..plugin import HaalCentraalHRPrefill

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ tests_require =
     black
     flake8
     coverage
+    zgw_consumers[testutils]
 [options.packages.find]
 include =
     prefill_haalcentraalhr
@@ -57,6 +58,7 @@ tests =
     black
     flake8
     coverage
+    zgw_consumers[testutils]
 pep8 = flake8
 docs =
     sphinx


### PR DESCRIPTION
It's being removed in Open Forms itself in favour of the utilities shipped with the library itself.